### PR TITLE
Fixes around signals

### DIFF
--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -63,6 +63,7 @@ internals.Engine.resume = function(engineState, executeOptionsOrCallback, callba
   const engine = new internals.Engine({
     name: engineState.name
   });
+  engine.started = true;
   debug(`<${engine.name}>`, 'resume');
 
   function resume() {

--- a/lib/events/MessageEvent.js
+++ b/lib/events/MessageEvent.js
@@ -10,8 +10,15 @@ module.exports = internals.MessageEvent = function() {
 
 internals.MessageEvent.prototype = Object.create(EventDefinition.prototype);
 
+internals.MessageEvent.prototype.run = function() {
+  this.waiting = true;
+  this.emit('wait', this);
+  EventDefinition.prototype.run.call(this);
+};
+
 internals.MessageEvent.prototype.signal = function(message) {
   this.message = message;
+  this.waiting = false;
   this.taken = true;
 
   this._debug(`<${this.id}>`, 'signaled');

--- a/lib/tasks/ServiceTask.js
+++ b/lib/tasks/ServiceTask.js
@@ -16,6 +16,7 @@ ServiceTask.prototype = Object.create(BaseTask.prototype);
 
 ServiceTask.prototype.execute = function(message) {
   this._debug(`<${this.id}>`, `execute ${this.service.name}`);
+  const wasTaken = this.taken;
   this.taken = true;
   this.emit('start', this);
 
@@ -33,7 +34,9 @@ ServiceTask.prototype.execute = function(message) {
   }
 
   const input = scope.getInput(message);
-  return this.service.execute(this, input, serviceCallback);
+  if (!wasTaken) {
+    return this.service.execute(this, input, serviceCallback)
+  }
 };
 
 ServiceTask.prototype.getInput = function(message) {


### PR DESCRIPTION
Hello, I fix (I hope!) two strange bugs:
1) After resume engine doesn't catch new signals
2) Bounded MessageEvent doesn't wait for signal and executes next blocks:

<img width="385" alt="2017-05-29 16 47 24" src="https://cloud.githubusercontent.com/assets/190940/26552133/8545516e-448e-11e7-9504-bc5209746068.png">
