### PR TITLE
Fix of multiinstance loop with iteration over collection

### DIFF
--- a/lib/activities/MultiInstanceLoopCharacteristics.js
+++ b/lib/activities/MultiInstanceLoopCharacteristics.js
@@ -33,11 +33,11 @@ MultiInstanceLoopCharacteristics.prototype.run = function(variables, message, re
 
   if (this.characteristics.collection) {
     const collection = this.getCollection(variables);
-    if (this.iteration > collection.length) {
+    if ( collection.length <= 1) {
       this.completed = true;
       debug('completed collection', this.completed);
     } else {
-      this.item = collection[this.iteration];
+      this.item = collection[0];
     }
   }
 

--- a/test/resume-task-loop-test.js
+++ b/test/resume-task-loop-test.js
@@ -18,7 +18,7 @@ lab.experiment('Resume task loop', () => {
   <process id="taskLoopProcess" isExecutable="true">
     <task id="recurring" name="Recurring">
       <multiInstanceLoopCharacteristics isSequential="true">
-        <loopCardinality xsi:type="tFormalExpression">5</loopCardinality>
+        <loopCardinality xsi:type="tFormalExpression">8</loopCardinality>
       </multiInstanceLoopCharacteristics>
     </task>
   </process>
@@ -57,7 +57,7 @@ lab.experiment('Resume task loop', () => {
       engine2.once('end', () => {
         testHelpers.expectNoLingeringListenersOnEngine(engine2);
 
-        expect(startCount).to.equal(5);
+        expect(startCount).to.equal(8);
         done();
       });
     });
@@ -100,7 +100,7 @@ lab.experiment('Resume task loop', () => {
       const options = {
         listener: listener1,
         variables: {
-          list: [7, 3, 2, 1]
+          list: [9, 8, 7, 6, 5, 4, 3, 2, 1]
         },
         services: {
           loop: {
@@ -125,7 +125,7 @@ lab.experiment('Resume task loop', () => {
         });
 
         engine2.once('end', (def) => {
-          expect(def.processes[0].variables.taskInput.recurring[0]).to.equal(13);
+          expect(def.processes[0].variables.taskInput.recurring[0]).to.equal(45);
           done();
         });
 

--- a/test/tasks/task-loop-test.js
+++ b/test/tasks/task-loop-test.js
@@ -381,14 +381,14 @@ lab.experiment('task loop', () => {
             }
           },
           variables: {
-            input: [1, 2, 3, 7]
+            input: [1, 2, 3, 7, 9]
           }
         }, (err, instance) => {
           if (err) return done(err);
 
           instance.once('end', () => {
-            expect(startCount).to.equal(4);
-            expect(instance.variables.sum).to.equal(13);
+            expect(startCount).to.equal(5);
+            expect(instance.variables.sum).to.equal(22);
             testHelpers.expectNoLingeringListenersOnDefinition(instance);
             done();
           });
@@ -431,7 +431,7 @@ lab.experiment('task loop', () => {
 
               const result = prevResult + executionContext.item;
 
-              if (result > 2) {
+              if (result > 6) {
                 return callback(new Error('Too much'));
               }
 
@@ -439,13 +439,13 @@ lab.experiment('task loop', () => {
             }
           },
           variables: {
-            input: [1, 2, 3, 7]
+            input: [1, 2, 3, 7, 9]
           }
         }, (err, instance) => {
           if (err) return done(err);
 
           instance.once('end', () => {
-            expect(startCount).to.equal(2);
+            expect(startCount).to.equal(4);
             testHelpers.expectNoLingeringListenersOnDefinition(instance);
             done();
           });


### PR DESCRIPTION
Fix of loop iteration over item collections bigger than 4.
Test in this pull request will fail on current loop implementation.