### PR TITLE
fix: set the correct `Logger` type in `BpmnEngineOptions`

### DIFF
--- a/test/Engine-test.js
+++ b/test/Engine-test.js
@@ -70,6 +70,43 @@ describe('Engine', () => {
       engine.name = 'still no source';
       expect(engine.name).to.equal('still no source');
     });
+
+    it('the "Logger" option is a factory function that accepts a scope and returns a Logger', (done) => {
+      const Logger = scope => ({
+        debug: (...args) => Logger.logs.push({scope, level: 'debug', args}),
+        warn: (...args) => Logger.logs.push({scope, level: 'warn', args}),
+        error: (...args) => Logger.logs.push({scope, level: 'error', args}),
+      });
+
+      Logger.logs = [];
+
+      const engine = Bpmn.Engine({
+        source: factory.valid(),
+        Logger
+      });
+
+      engine.execute();
+
+      engine.on('end', () => {
+        expect(Logger.logs).to.have.length.gte(1);
+        done();
+      });
+    });
+
+    it('throw an error when the "Logger" option is not a valid factory', () => {
+      const Logger = {
+        debug: (...args) => Logger.logs.push({level: 'debug', args}),
+        warn: (...args) => Logger.logs.push({level: 'warn', args}),
+        error: (...args) => Logger.logs.push({level: 'error', args}),
+      };
+
+      Logger.logs = [];
+
+      expect(() => Bpmn.Engine({
+        source: factory.valid(),
+        Logger
+      })).to.throw(TypeError, 'Logger is not a function');
+    });
   });
 
   describe('async getDefinitions()', () => {

--- a/types/bpmn-engine.d.ts
+++ b/types/bpmn-engine.d.ts
@@ -218,7 +218,7 @@ declare module 'bpmn-engine' {
     /**
      * optional Logger factory, defaults to debug logger
      */
-    Logger?: BpmnLogger;
+    Logger?: (scope: string) => BpmnLogger;
 
     /**
      * optional inline script handler, defaults to nodejs vm module handling, i.e. JavaScript


### PR DESCRIPTION
The `Logger` type in `BpmnEngineOptions` is not correct, it should be a function that returns a `BpmnLogger` instead of a `BpmbLogger` itself