### PR TITLE
fix(types): add missing `moddleContext` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "nyc": "^15.1.0"
   },
   "dependencies": {
+    "@types/bpmn-moddle": "^5.1.6",
     "bpmn-elements": "^8.1.0",
     "bpmn-moddle": "^7.0.4",
     "debug": "^4.3.4",

--- a/types/bpmn-engine.d.ts
+++ b/types/bpmn-engine.d.ts
@@ -1,6 +1,7 @@
 // Author : Saeed Tabrizi
 
 import {EventEmitter} from 'events';
+import {Definitions} from 'bpmn-moddle';
 
 declare module 'bpmn-engine' {
 
@@ -236,6 +237,7 @@ declare module 'bpmn-engine' {
      * optional bpmn-moddle options to be passed to bpmn-moddle
      */
     moddleOptions?: any;
+    moddleContext?: Definitions;
 
     extensions?: BpmnEngineExtension;
     /**


### PR DESCRIPTION
Add missing `moddleContext` option to `BpmnEngineOptions`